### PR TITLE
-fix: behaviour resetOn of (pool, scriptable variable, scriptable list)

### DIFF
--- a/Assets/Heart/Core/Runtime/Enum.cs
+++ b/Assets/Heart/Core/Runtime/Enum.cs
@@ -23,8 +23,19 @@ namespace Pancake
 
     public enum ResetType
     {
-        SceneLoaded,
-        ApplicationStarts,
+        /// <summary>
+        /// Each scene loaded by LoadSceneMode.Single
+        /// </summary>
+        SceneLoaded = 0,
+
+        /// <summary>
+        /// Each scene loaded by LoadSceneMode.Additive.</br>
+        /// Use this option for compatibility with the use of LoadSceneMode.Additive instead of LoadSingle Scene introduced in foundation,
+        /// to keep the variable's value reset behavior similar to SceneLoaded. </br>
+        /// If you are not using a flow load scene like in foundation or you are not sure how to reset the value when the load scene is adaptive, do not use this option.
+        /// </summary>
+        AdditiveSceneLoaded = 2,
+        ApplicationStarts = 1,
     }
 
     public enum StartupMode

--- a/Assets/Heart/Core/Runtime/Pool/ComponentPool.cs
+++ b/Assets/Heart/Core/Runtime/Pool/ComponentPool.cs
@@ -1,3 +1,4 @@
+using System;
 using UnityEngine;
 
 namespace Pancake
@@ -65,6 +66,21 @@ namespace Pancake
         {
             base.OnDisable();
             if (_root != null) _root.gameObject.Destroy();
+        }
+
+        protected override void CleanPool()
+        {
+            try
+            {
+                foreach (var component in container)
+                {
+                    if (component != null) Destroy(component.gameObject);
+                }
+            }
+            catch (Exception)
+            {
+                // ignored
+            }
         }
     }
 }

--- a/Assets/Heart/Core/Runtime/Pool/GameObjectPool.cs
+++ b/Assets/Heart/Core/Runtime/Pool/GameObjectPool.cs
@@ -1,3 +1,4 @@
+using System;
 using Pancake.Apex;
 
 namespace Pancake
@@ -81,6 +82,21 @@ namespace Pancake
             member.transform.SetParent(Root);
             member.gameObject.SetActive(false);
             return member;
+        }
+
+        protected override void CleanPool()
+        {
+            try
+            {
+                foreach (var instance in container)
+                {
+                    if (instance != null) instance.Destroy();
+                }
+            }
+            catch (Exception)
+            {
+               // ignored
+            }
         }
 
         public override void OnDisable()

--- a/Assets/Heart/Modules/Scriptable/Runtime/ScriptableLists/ScriptableList.cs
+++ b/Assets/Heart/Modules/Scriptable/Runtime/ScriptableLists/ScriptableList.cs
@@ -3,6 +3,7 @@ using UnityEngine;
 using System;
 using System.Collections;
 using System.Linq;
+using Pancake.Apex;
 using UnityEngine.SceneManagement;
 using Object = UnityEngine.Object;
 
@@ -10,8 +11,10 @@ namespace Pancake.Scriptable
 {
     public abstract class ScriptableList<T> : ScriptableListBase, IReset, IEnumerable<T>, IDrawObjectsInInspector
     {
-        [Tooltip("Clear the list when:" + " Scene Loaded : when a scene is loaded." +
-                 " Application Start : Once, when the application starts. Modifications persists between scenes")]
+        [Message("Clear the list when:" + "\nScene Loaded : when the scene is loaded by LoadSceneMode.Single" +
+                 "\nAdditive Scene Loaded : when the scene is loaded by LoadSceneMode.Additive" +
+                 "\nApplication Start : Once, when the application starts. Modifications persists between scenes",
+            Height = 58)]
         [SerializeField]
         private ResetType resetOn = ResetType.SceneLoaded;
 
@@ -135,7 +138,7 @@ namespace Pancake.Scriptable
         {
             Clear();
 
-            if (resetOn == ResetType.SceneLoaded) SceneManager.sceneLoaded += OnSceneLoaded;
+            if (resetOn is ResetType.SceneLoaded or ResetType.AdditiveSceneLoaded) SceneManager.sceneLoaded += OnSceneLoaded;
 #if UNITY_EDITOR
             UnityEditor.EditorApplication.playModeStateChanged += OnPlayModeStateChanged;
 #endif
@@ -143,7 +146,7 @@ namespace Pancake.Scriptable
 
         private void OnDisable()
         {
-            if (resetOn == ResetType.SceneLoaded) SceneManager.sceneLoaded -= OnSceneLoaded;
+            if (resetOn is ResetType.SceneLoaded or ResetType.AdditiveSceneLoaded) SceneManager.sceneLoaded -= OnSceneLoaded;
 #if UNITY_EDITOR
             UnityEditor.EditorApplication.playModeStateChanged -= OnPlayModeStateChanged;
 #endif
@@ -151,7 +154,7 @@ namespace Pancake.Scriptable
 
         private void OnSceneLoaded(Scene scene, LoadSceneMode mode)
         {
-            if (mode == LoadSceneMode.Single) Clear();
+            if ((resetOn == ResetType.SceneLoaded && mode == LoadSceneMode.Single) || resetOn == ResetType.AdditiveSceneLoaded && mode == LoadSceneMode.Additive) Clear();
         }
 
         public override void Reset()

--- a/Assets/_Root/Storages/Generated/Audio/SoundEmitterPool.asset
+++ b/Assets/_Root/Storages/Generated/Audio/SoundEmitterPool.asset
@@ -13,4 +13,5 @@ MonoBehaviour:
   m_Name: SoundEmitterPool
   m_EditorClassIdentifier: 
   developerDescription: 
+  resetOn: 1
   factory: {fileID: 11400000, guid: 076cafc4f6524554daf38f260ceff90f, type: 2}

--- a/Assets/_Root/Storages/Pool/Fx/fx_coin_pool.asset
+++ b/Assets/_Root/Storages/Pool/Fx/fx_coin_pool.asset
@@ -14,4 +14,6 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   developerDescription: coin fx pool using for spawn fx coin when user receive coin
     when build from shop or win level
+  resetOn: 1
   factory: {fileID: 11400000, guid: d58bbac3f0f0ad546b0b447f351826ea, type: 2}
+  rootIsUI: 0


### PR DESCRIPTION
- sound emitter pool, fx_coin_pool  now use type reset on is `ApplicationStarts`
- add type `AdditiveSceneLoaded` in enum `ResetType `, behaviour of AdditiveSceneLoaded same as SceneLoaded but because scene flow introduce of foundation using `LoadSceneMode.Additive` so if type resetOn is `SceneLoaded`  (load scene by `LoadSceneMode.Single`) not work correctly
- pool now destroy instance created when reset
- correct the corresponding behavior where `ResetType` is used when adding `AdditiveSceneLoaded`