### PR TITLE
-add: locale text composite component

### DIFF
--- a/Assets/Heart/Modules/Localization/Runtime/Implement/Behaviour/LocaleTextComponent.cs
+++ b/Assets/Heart/Modules/Localization/Runtime/Implement/Behaviour/LocaleTextComponent.cs
@@ -22,10 +22,7 @@ namespace Pancake.Localization
             }
         }
 
-        public void UpdateArgs(params string[] args)
-        {
-            FormatArgs = args;
-        }
+        public void UpdateArgs(params string[] args) { FormatArgs = args; }
 
         protected override object GetLocaleValue()
         {

--- a/Assets/Heart/Modules/Localization/Runtime/Implement/Behaviour/LocaleTextCompositeComponent.cs
+++ b/Assets/Heart/Modules/Localization/Runtime/Implement/Behaviour/LocaleTextCompositeComponent.cs
@@ -1,0 +1,103 @@
+using System;
+using System.Linq;
+using System.Text;
+using System.Text.RegularExpressions;
+using Pancake.Apex;
+using TMPro;
+using UnityEngine;
+using UnityEngine.UI;
+
+namespace Pancake.Localization
+{
+    [EditorIcon("csharp")]
+    public class LocaleTextCompositeComponent : LocaleComponentGenericBase
+    {
+        [SerializeField] private string seperate = ", ";
+        [SerializeField, Array] private LocaleText[] variables;
+        [SerializeField, Array] private string[] formatArgs = Array.Empty<string>();
+
+        public string[] FormatArgs
+        {
+            get => formatArgs;
+            set
+            {
+                formatArgs = value ?? Array.Empty<string>();
+                ForceUpdate();
+            }
+        }
+
+        public LocaleText[] Variables
+        {
+            get => variables;
+            set
+            {
+                variables = value;
+                ForceUpdate();
+            }
+        }
+
+        public void UpdateArgs(params string[] args) { FormatArgs = args; }
+
+        public void UpdateVariables(params LocaleText[] args) { Variables = args; }
+
+        protected override Type GetValueType() => typeof(string);
+
+        protected override bool HasLocaleValue() => variables is {Length: > 0};
+
+        protected override object GetLocaleValue()
+        {
+            (string value, int totalArgs) = CompositeString(seperate);
+            if (FormatArgs.Length >= totalArgs && !string.IsNullOrEmpty(value))
+            {
+                return string.Format(value, FormatArgs.Cast<object>().ToArray());
+            }
+
+            return value;
+        }
+
+        private (string, int) CompositeString(string seperate = ", ")
+        {
+            var index = 0;
+            var result = string.Empty;
+            var stringBuilder = new StringBuilder();
+            foreach (var text in variables)
+            {
+                string temp = GetValueOrDefault(text);
+                const string pattern = @"{(.*?)}";
+                int count = Regex.Matches(temp, pattern).OfType<Match>().Select(m => m.Value).Distinct().Count();
+                int j = count - 1 + index;
+                for (int i = count - 1; i >= 0; i--)
+                {
+                    stringBuilder.Clear();
+                    stringBuilder.Append("{");
+                    stringBuilder.Append(i);
+                    var old = stringBuilder.ToString();
+                    stringBuilder.Clear();
+                    stringBuilder.Append("{");
+                    stringBuilder.Append(j);
+                    temp = temp.Replace(old, stringBuilder.ToString());
+                    index++;
+                    j--;
+                }
+
+                stringBuilder.Clear();
+                if (!string.IsNullOrEmpty(result))
+                {
+                    stringBuilder.Append(result);
+                    stringBuilder.Append(seperate);
+                }
+
+                stringBuilder.Append(temp);
+                result = stringBuilder.ToString();
+            }
+
+            return (result, index);
+        }
+
+        private void Reset()
+        {
+            TrySetComponentAndPropertyIfNotSet<Text>("text");
+            TrySetComponentAndPropertyIfNotSet<TextMeshProUGUI>("text");
+        }
+    }
+}

--- a/Assets/Heart/Modules/Localization/Runtime/Implement/Behaviour/LocaleTextCompositeComponent.cs.meta
+++ b/Assets/Heart/Modules/Localization/Runtime/Implement/Behaviour/LocaleTextCompositeComponent.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 70f72d8f5ec175e4f9f6dff221346f2b
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {fileID: 2800000, guid: 8ee9252e2703a1047a5ace5a488bfe4e, type: 3}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
### Provides composite feature for locale text when your data needs to be merged from many different locale texts.
The number of elements in the args array must be equal to or greater than the total number of params for the entire locale

![image](https://github.com/pancake-llc/foundation/assets/44673303/eff3ad26-0a7b-4321-bc71-e448c3bddb0f)

### Result 

![image](https://github.com/pancake-llc/foundation/assets/44673303/e91fe369-81ee-4a23-bc54-ca3c2b2210b0)
