### PR TITLE
add: hierarchy nullable attribute to ignore collect error in hierarchy

### DIFF
--- a/Assets/Heart/Core/Editor/Drawer/Hierarchy/ErrorComponent.cs
+++ b/Assets/Heart/Core/Editor/Drawer/Hierarchy/ErrorComponent.cs
@@ -3,6 +3,7 @@ using System.Collections;
 using System.Collections.Generic;
 using System.Reflection;
 using System.Text;
+using Pancake;
 using Pancake.ExLibEditor;
 using UnityEditor;
 using UnityEditorInternal;
@@ -151,7 +152,9 @@ namespace PancakeEditor.Hierarchy
                             {
                                 var field = fieldArray[j];
 
-                                if (Attribute.IsDefined(field, typeof(HideInInspector)) || Attribute.IsDefined(field, typeof(NonSerializedAttribute)) ||
+                                if (Attribute.IsDefined(field, typeof(HideInInspector))
+                                    || Attribute.IsDefined(field, typeof(HierarchyNullableAttribute))
+                                    || Attribute.IsDefined(field, typeof(NonSerializedAttribute)) ||
                                     field.IsStatic) continue;
 
                                 if (field.IsPrivate || !field.IsPublic)

--- a/Assets/Heart/Core/Runtime/HierarchyNullableAttribute.cs
+++ b/Assets/Heart/Core/Runtime/HierarchyNullableAttribute.cs
@@ -1,0 +1,8 @@
+﻿using UnityEngine;
+
+namespace Pancake
+{
+    public class HierarchyNullableAttribute : PropertyAttribute
+    {
+    }
+}

--- a/Assets/Heart/Core/Runtime/HierarchyNullableAttribute.cs.meta
+++ b/Assets/Heart/Core/Runtime/HierarchyNullableAttribute.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: cdb956ec0002478c8c5f94dc43607530
+timeCreated: 1705043657

--- a/Assets/Heart/Modules/Component/Runtime/VfxMagnetComponent.cs
+++ b/Assets/Heart/Modules/Component/Runtime/VfxMagnetComponent.cs
@@ -20,7 +20,10 @@ namespace Pancake.Component
         [SerializeField, ShowIf(nameof(isPlaySound))] private Audio audioSpawn;
         [SerializeField, ShowIf(nameof(isPlaySound))] private ScriptableEventAudio audioPlayEvent;
         [Space] [SerializeField] private bool useCanvasMaster;
-        [SerializeField, HideIf(nameof(useCanvasMaster))] private Transform canvas;
+
+        [SerializeField, HideIf(nameof(useCanvasMaster)), HierarchyNullable]
+        private Transform canvas;
+
         [SerializeField, ShowIf(nameof(useCanvasMaster))] private ScriptableEventGetGameObject getCanvasMasterEvent;
 
 

--- a/Assets/Heart/Modules/UGUI/Runtime/Button/UIButton.cs
+++ b/Assets/Heart/Modules/UGUI/Runtime/Button/UIButton.cs
@@ -52,7 +52,7 @@ namespace Pancake.UI
         [SerializeField] private bool ignoreTimeScale;
         [SerializeField] private bool isMotionUnableInteract;
         [SerializeField] private bool isAffectToSelf = true;
-        [SerializeField] private Transform affectObject;
+        [SerializeField, HierarchyNullable] private Transform affectObject;
         [SerializeField] private bool enabledSound;
         [SerializeField] private Audio audioClick;
         [SerializeField] private ScriptableEventAudio audioPlayEvent;

--- a/Assets/_Root/Editor/Resources/HierarchyEditorSetting.asset
+++ b/Assets/_Root/Editor/Resources/HierarchyEditorSetting.asset
@@ -32,7 +32,7 @@ MonoBehaviour:
   enabledVisibility: 1
   visibilityShowDuringPlayMode: 1
   enabledError: 1
-  showIconOnParent: 0
+  showIconOnParent: 1
   showScriptMissing: 1
   showReferenceNull: 0
   showReferenceIsMissing: 1


### PR DESCRIPTION
Usage [HierarchyNullable] ignore warning missing reference in hierarchy when setting `Missing Reference` enabled 

![image](https://github.com/pancake-llc/foundation/assets/44673303/8ac80f3c-37a3-4c8a-a6a2-36b96b340300)
